### PR TITLE
Mark gomqtt/client/tracker as a public struct

### DIFF
--- a/client/tracker.go
+++ b/client/tracker.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-// a tracker keeps track of keep alive intervals
-type tracker struct {
+// Tracker a tracker keeps track of keep alive intervals
+type Tracker struct {
 	sync.RWMutex
 
 	last    time.Time
@@ -14,48 +14,48 @@ type tracker struct {
 	timeout time.Duration
 }
 
-// returns a new tracker
-func newTracker(timeout time.Duration) *tracker {
-	return &tracker{
+// NewTracker returns a new tracker
+func NewTracker(timeout time.Duration) *Tracker {
+	return &Tracker{
 		last:    time.Now(),
 		timeout: timeout,
 	}
 }
 
-// updates the tracker
-func (t *tracker) reset() {
+// Reset updates the tracker
+func (t *Tracker) Reset() {
 	t.Lock()
 	defer t.Unlock()
 
 	t.last = time.Now()
 }
 
-// returns the current time window
-func (t *tracker) window() time.Duration {
+// Window returns the current time window
+func (t *Tracker) Window() time.Duration {
 	t.RLock()
 	defer t.RUnlock()
 
 	return t.timeout - time.Since(t.last)
 }
 
-// mark ping
-func (t *tracker) ping() {
+// Ping mark ping
+func (t *Tracker) Ping() {
 	t.Lock()
 	defer t.Unlock()
 
 	t.pings++
 }
 
-// mark pong
-func (t *tracker) pong() {
+// Pong mark pong
+func (t *Tracker) Pong() {
 	t.Lock()
 	defer t.Unlock()
 
 	t.pings--
 }
 
-// returns if pings are pending
-func (t *tracker) pending() bool {
+// Pending returns if pings are pending
+func (t *Tracker) Pending() bool {
 	t.RLock()
 	defer t.RUnlock()
 

--- a/client/tracker_test.go
+++ b/client/tracker_test.go
@@ -8,19 +8,19 @@ import (
 )
 
 func TestTracker(t *testing.T) {
-	tracker := newTracker(10 * time.Millisecond)
-	assert.False(t, tracker.pending())
-	assert.True(t, tracker.window() > 0)
+	tracker := NewTracker(10 * time.Millisecond)
+	assert.False(t, tracker.Pending())
+	assert.True(t, tracker.Window() > 0)
 
 	time.Sleep(10 * time.Millisecond)
-	assert.True(t, tracker.window() <= 0)
+	assert.True(t, tracker.Window() <= 0)
 
-	tracker.reset()
-	assert.True(t, tracker.window() > 0)
+	tracker.Reset()
+	assert.True(t, tracker.Window() > 0)
 
-	tracker.ping()
-	assert.True(t, tracker.pending())
+	tracker.Ping()
+	assert.True(t, tracker.Pending())
 
-	tracker.pong()
-	assert.False(t, tracker.pending())
+	tracker.Pong()
+	assert.False(t, tracker.Pending())
 }


### PR DESCRIPTION
gomqtt is a very good libs and used in our projects, thank all gomqtt contributors. But because some logics of our projects are different from gomqtt's, we cannot use some gomqtt's public structs directly. For example, we need a mqtt client with auto-reconnect feature and without any message cache in memory, so we must implement it by myself and in order to avoid to copy code we hope gomqtt/client/tracker can be marked as a public struct.