### PR TITLE
conditionally announce message on Publish (enabling server to retry) …

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -41,6 +41,14 @@ type Config struct {
 	// MaxWriteDelay defines the maximum allowed delay when flushing the
 	// underlying buffered writer.
 	MaxWriteDelay time.Duration
+
+	// AlwaysAnnounceOnPublish defines when the message callback handler is called.
+	// QOS 0,1: callback always occurs on reception of Publish
+	// QOS 2 and AlwaysAnnounceOnPublish == false: callback occurs on reception of PubRel and returning and error in
+	//   the callback will close the connection before PubComp is sent.
+	// QOS 2 and AlwaysAnnounceOnPublish == true: callback occurs on reception of Publish and returning an error in
+	//   the callback will close the connection, preventing PubRec being sent, thus ensuring redelivery of publish.
+	AlwaysAnnounceOnPublish bool
 }
 
 // NewConfig creates a new Config using the specified URL.


### PR DESCRIPTION
…or hold until Pubrel (having certainty the broker won't redeliver).

Add tests for both behaviours.